### PR TITLE
If response contains a status code, pass this back up the chain as an Object.

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -177,6 +177,10 @@
           var _ref1;
           if ((200 <= (_ref1 = response.statusCode) && _ref1 <= 299)) {
             return _this.wrap_response(fn, err, response, _this._try_to_serialize(response, body));
+          } else if (response != null ? response.statusCode : void 0) {
+            return _this.wrap_response(fn, {
+              "statusCode": response.statusCode
+            }, response, null);
           } else {
             return _this.wrap_response(fn, true, response, null);
           }

--- a/src/API.coffee
+++ b/src/API.coffee
@@ -121,6 +121,8 @@ API = callable class
     handle = (err, response, body) =>
       if 200 <= response.statusCode <= 299
         return @wrap_response fn, err, response, @_try_to_serialize(response, body)
+      else if response?.statusCode
+        return @wrap_response fn, { "statusCode": response.statusCode }, response, null
       else
         return @wrap_response fn, true, response, null
 


### PR DESCRIPTION
We can then check for `err?.statusCode` later, rather than having to test for `statusCode` in the `response` object, which feels weird when `err` is true.
