### PR TITLE
make formadta key only be added on POST

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -125,7 +125,7 @@
         }
         request_options[prop] = kwargs.data;
       }
-      if ((kwargs.formData != null) && method !== 'GET') {
+      if ((kwargs.formData != null) && method === 'POST') {
         request_options.formData = kwargs.formData;
       }
       if (this.opts.auth) {

--- a/src/API.coffee
+++ b/src/API.coffee
@@ -83,7 +83,7 @@ API = callable class
 
       request_options[prop] = kwargs.data
 
-    if kwargs.formData? && method isnt 'GET'
+    if kwargs.formData? && method is 'POST'
       request_options.formData = kwargs.formData
 
     if @opts.auth


### PR DESCRIPTION
looks like in fails on PUT either. I guess the formdata field makes only sense on POST requests.
