### PR TITLE
With XHR, allow any headers to be set by options

### DIFF
--- a/src/API.coffee
+++ b/src/API.coffee
@@ -100,12 +100,6 @@ API = callable class
       defaultVersion = require('../package.json').version
       request_options.headers['User-Agent'] = "node-slumber/#{defaultVersion}"
 
-    if @opts.http_client == 'xhr'
-      white_listed_headers = [ 'authorization', 'accept' ]
-      for key, value of request_options.headers
-        if key.toLowerCase() not in white_listed_headers
-          delete request_options.headers[key]
-
     return request_options
 
 


### PR DESCRIPTION
Removes the `white_listed_headers` which prevents clients from specifying arbitrary headers in an XHR request.

@smith-kyle is a former colleague of mine who originally added XHR support for use with our fork of `node-gitlab`. Included in that PR is a "header whitelist" that deletes all headers from the XHR request options that are not explicitly in the whitelist.

Unfortunately, as we pursue support for GitLab personal access tokens in our application, the whitelist is getting in the way, because GitLab demands that such tokens be in the `Private-Token` header - which is not currently in the whitelist.  I contacted him and he has no recollection as to why the whitelist was created. I have tried removing the whitelist and there do not seem to be any immediate problems.

I see no reason why someone using this library shouldn't be able to set headers on XHR requests arbitrarily if they so choose.

(Incidentally, our fork of `node-gitlab` may have useful changes, and we'd like to give back, but a lot of the knowledge of what was done has been lost... we only know that it "just works" for our purposes. If you want to take a look to see if you might be interested, [this branch](https://github.com/Axosoft/node-gitlab/tree/gitkraken) has what we're currently using. Let me know if you want to proceed and I can open an issue or pr on `node-gitlab`, or we can talk about what it would take to get to that point.)